### PR TITLE
Implement ERC1155 listing exclusions

### DIFF
--- a/contracts/Aavegotchi/facets/DAOFacet.sol
+++ b/contracts/Aavegotchi/facets/DAOFacet.sol
@@ -35,6 +35,7 @@ contract DAOFacet is Modifiers {
     event ItemGeistBridgeUpdate(address _newBridge);
     event GHSTContractUpdate(address _newGHSTContract);
     event BaazaarTradingAllowlistUpdate(address _contract, bool _allow);
+    event ERC1155ListingExclusionUpdate(address indexed token, uint256 indexed id, bool excluded);
     event WearableDiamondUpdate(address _wearableDiamond);
     event ForgeDiamondUpdate(address _forgeDiamond);
     /***********************************|
@@ -464,6 +465,14 @@ contract DAOFacet is Modifiers {
 
     function getBaazaarTradingAllowlist(address _contract) external view returns (bool) {
         return s.baazaarTradingAllowlist[_contract];
+    }
+
+    function setERC1155ListingExclusions(address token, uint256[] calldata ids, bool[] calldata flags) external onlyDaoOrOwner {
+        require(ids.length == flags.length, "DAOFacet: ids and flags mismatch");
+        for (uint256 i; i < ids.length; i++) {
+            s.erc1155ListingExclusions[token][ids[i]] = flags[i];
+            emit ERC1155ListingExclusionUpdate(token, ids[i], flags[i]);
+        }
     }
 
     function setWearableDiamond(address _wearableDiamond) external onlyDaoOrOwner {

--- a/contracts/Aavegotchi/facets/ERC1155MarketplaceFacet.sol
+++ b/contracts/Aavegotchi/facets/ERC1155MarketplaceFacet.sol
@@ -119,6 +119,10 @@ contract ERC1155MarketplaceFacet is Modifiers {
     ) internal {
         address seller = LibMeta.msgSender();
         uint256 category = LibSharedMarketplace.getERC1155Category(_erc1155TokenAddress, _erc1155TypeId);
+        require(
+            !LibSharedMarketplace.isERC1155ListingExcluded(_erc1155TokenAddress, _erc1155TypeId),
+            "ERC1155Marketplace: token excluded"
+        );
 
         IERC1155 erc1155Token = IERC1155(_erc1155TokenAddress);
         require(erc1155Token.balanceOf(seller, _erc1155TypeId) >= _quantity, "ERC1155Marketplace: Not enough ERC1155 token");

--- a/contracts/Aavegotchi/libraries/LibAppStorage.sol
+++ b/contracts/Aavegotchi/libraries/LibAppStorage.sol
@@ -395,6 +395,8 @@ struct AppStorage {
     uint256 nextERC1155BuyOrderId;
     mapping(uint256 => ERC1155BuyOrder) erc1155BuyOrders; // buyOrderId => data
     mapping(address => bool) baazaarTradingAllowlist; // allowlist for baazaar trading
+    // tokenAddress => tokenId => isExcluded
+    mapping(address => mapping(uint256 => bool)) erc1155ListingExclusions;
     //proofofplay vrf
     address VRFSystem;
 }

--- a/contracts/Aavegotchi/libraries/LibSharedMarketplace.sol
+++ b/contracts/Aavegotchi/libraries/LibSharedMarketplace.sol
@@ -141,4 +141,9 @@ library LibSharedMarketplace {
             require(s.itemTypes[_erc1155TypeId].maxQuantity > 0, "ERC1155Marketplace: erc1155 item not supported");
         }
     }
+
+    function isERC1155ListingExcluded(address _erc1155TokenAddress, uint256 _id) internal view returns (bool) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        return s.erc1155ListingExclusions[_erc1155TokenAddress][_id];
+    }
 }

--- a/test/erc1155ListingExclusionsTest.ts
+++ b/test/erc1155ListingExclusionsTest.ts
@@ -1,0 +1,43 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { DAOFacet, ERC1155MarketplaceFacet } from "../typechain";
+import { deployFullDiamond } from "../scripts/deployFullDiamond";
+
+describe("ERC1155 Listing Exclusions", function () {
+  this.timeout(200000);
+  let daoFacet: DAOFacet;
+  let erc1155Facet: ERC1155MarketplaceFacet;
+  let diamondAddress: string;
+  const itemId = 138;
+
+  before(async () => {
+    const { aavegotchiDiamond, testGhstContractAddress } = await deployFullDiamond();
+    diamondAddress = aavegotchiDiamond.address;
+    daoFacet = (await ethers.getContractAt("DAOFacet", diamondAddress)) as DAOFacet;
+    erc1155Facet = (await ethers.getContractAt(
+      "ERC1155MarketplaceFacet",
+      diamondAddress
+    )) as ERC1155MarketplaceFacet;
+
+    const ghst = await ethers.getContractAt(
+      "contracts/test/ERC20Token.sol:ERC20Token",
+      testGhstContractAddress
+    );
+    await ghst.mint();
+    await daoFacet.mintItems(await ethers.provider.getSigner(0).getAddress(), [itemId], [1]);
+  });
+
+  it("reverts when listing excluded item", async () => {
+    await daoFacet.setERC1155ListingExclusions(diamondAddress, [itemId], [true]);
+    await expect(
+      erc1155Facet.setERC1155Listing(diamondAddress, itemId, 1, ethers.utils.parseEther("1"))
+    ).to.be.revertedWith("ERC1155Marketplace: token excluded");
+  });
+
+  it("allows listing when exclusion removed", async () => {
+    await daoFacet.setERC1155ListingExclusions(diamondAddress, [itemId], [false]);
+    await expect(
+      erc1155Facet.setERC1155Listing(diamondAddress, itemId, 1, ethers.utils.parseEther("1"))
+    ).to.emit(erc1155Facet, "ERC1155ListingAdd");
+  });
+});


### PR DESCRIPTION
## Summary
- add `erc1155ListingExclusions` mapping to `AppStorage`
- implement `isERC1155ListingExcluded` utility
- allow DAO to set exclusions via `setERC1155ListingExclusions`
- forbid creating listings for excluded ids
- add tests covering listing exclusion behaviour

## Testing
- `npx hardhat test test/erc1155ListingExclusionsTest.ts` *(fails: 403 Forbidden when attempting to download hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_684a3e66ed0883259306885da63a2d68